### PR TITLE
fix(index.js): windows平台的斜杠错误

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ class WebpackAliyunOss {
 				while (i++ < len) {
 					filePath = files.shift();
 
-					let ossFilePath = (dist + (setOssPath && setOssPath(filePath) || (inWebpack && splitToken && filePath.split(splitToken)[1] || ''))).replace(/\/\/+/g, '/');
+					let ossFilePath = (dist + (setOssPath && setOssPath(filePath) || (inWebpack && splitToken && filePath.split(splitToken)[1] || '').replace(/\\/g, '/'))).replace(/\/\/+/g, '/');
 
 					if (test) {
 						console.log(filePath.gray, '\n is ready to upload to '.green + ossFilePath);


### PR DESCRIPTION
filePath.split(splitToken)[1] || '')在windows上生成是含有‘/’的路径，需要将其转为‘/’